### PR TITLE
added _auto as condition for creating a geo_column

### DIFF
--- a/base_geoengine/geo_model.py
+++ b/base_geoengine/geo_model.py
@@ -65,7 +65,7 @@ class GeoModel(models.BaseModel):
         res = super(GeoModel, self)._auto_init(cursor, context)
         column_data = self._select_column_data(cursor)
         for kol in geo_columns:
-            if not isinstance(geo_columns[kol], fields.function):
+            if not isinstance(geo_columns[kol], fields.function) and self._auto:
                 fct = geo_columns[kol].create_geo_column
                 if kol in column_data:
                     fct = geo_columns[kol].update_geo_column


### PR DESCRIPTION
added self._auto as condition for creating a geo_column, 
this is necessary when you want to create a "view model",
(_auto = False) in the declaration of your model. Otherwise you got an error because geo_engine tries to create the geo_column.

example:

class GeoPositionsView(geo_model.GeoModel):
    _name = "geo.positions.view"
    _auto = False

```
field1= fields.Char('field1',size=128, readonly=True)
field2= fields.Many2one('another.model', String='field2', readonly=True)
...
geo_field1 = geo_fields.GeoPoint('position', readonly=True)

def init(self, cr):
    tools.sql.drop_view_if_exists(cr, 'geo_positions_view')
    cr.execute("""
        CREATE view geo_positions_view as
            ( SELECT *, ST_Transform(ST_SetSRID(ST_MakePoint(longitude, latitude), 4326), 900913) as geo_point from positions )
        """)
```
